### PR TITLE
Migliorie varie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
+
+      - run:
+          name: Run linters
+          command: yarn lint
+
+      - run:
+          name: Run tests
+          command: yarn test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://img.shields.io/circleci/project/github/matteogll/holiday-planner-fe.svg)](https://circleci.com/gh/matteogll/holiday-planner-fe)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "antd": "^3.12.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.10.0",
-    "expect": "^23.6.0",
     "moment": "^2.23.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "private": true,
   "dependencies": {
     "antd": "^3.12.0",
-    "enzyme": "^3.8.0",
-    "enzyme-adapter-react-16": "^1.10.0",
     "moment": "^2.23.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
+    "react-router-dom": "^4.3.1"
+  },
+  "devDependencies": {
+    "enzyme": "^3.8.0",
+    "enzyme-adapter-react-16": "^1.10.0",
     "react-scripts": "2.1.3",
     "sinon": "^7.2.5"
   },
@@ -20,9 +22,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.js src/**/*.jsx"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   },
   "browserslist": [
     ">0.2%",

--- a/src/components/AddHolidayForm.jsx
+++ b/src/components/AddHolidayForm.jsx
@@ -187,7 +187,7 @@ class AddHolidayForm extends Component {
                 // Validate RESPONSIBLE
                 const firstResponsible = fieldsValues["first_responsible"];
                 const secondReponsible = fieldsValues["second_responsible"];
-                if(firstResponsible == secondReponsible) {
+                if(firstResponsible === secondReponsible) {
                     console.log("Second responsible must be different from First responsible");
                     Modal.error({
                         title: "Second responsible error",

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -1,11 +1,10 @@
-import React from 'react';
-import { shallow } from '../enzyme';
-import expect from "expect";
+import { shallow } from "enzyme";
+import React from "react";
 
-import Header from './Header';
+import Header from "./Header";
 
 describe("Header component", () => {
-    it('renders Menu.Item components', () => {
+    it("renders Menu.Item components", () => {
         const wrapper = shallow(<Header />);
         expect(wrapper.find(".menu")).toBeDefined();
         expect(wrapper.find(".menu-item").length).toEqual(4);

--- a/src/enzyme.js
+++ b/src/enzyme.js
@@ -1,7 +1,0 @@
-// See: https://scotch.io/tutorials/testing-react-components-with-enzyme-and-jest
-import Enzyme, { configure, shallow, mount, render } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure({ adapter: new Adapter() });
-export { shallow, mount, render };
-export default Enzyme;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
Refactors:

- rimuove il modulo npm `expect`, poiché Jest - il test runner incluso in
  create-react-app - ha già un suo `expect` (ha un'API molto simile, è esportato
  come variabile globale)
- sposta il setup di enzyme nel file `setupTest.js`, come da [convenzione
  create-react-app](https://facebook.github.io/create-react-app/docs/running-tests#src-setuptestsjs)

Fixes:

- fixa un errore di linting

Chores:

- setup della CI su CircleCI (TODO: @matteogll quando rendi pubblica la repo devi fare il login su CircleCI e abilitare questa repo)
- sposta le dipendenze di sviluppo nelle `devDependencies` del `package.json`